### PR TITLE
Feat/ TMAP API (자동차 경로안내, 보행자 경로안내) 연동 완료

### DIFF
--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -1,7 +1,7 @@
 // sigo-travel-time/src/handlers.rs
 // 각 HTTP 요청을 수행하는 핸들러 함수들을 작성 (서비스)
 
-use super::models::TMAPtransitAPIInput;
+use super::models::{TMAPAPIInput, TMAPtransitAPIInput};
 use super::state::AppState;
 use actix_web::{web, HttpResponse};
 use serde_json::Value;
@@ -54,7 +54,7 @@ pub async fn get_travel_time_by_transit(
 }
 
 pub async fn get_travel_time_by_driving(
-    api_input_info: web::Json<TMAPtransitAPIInput>,
+    api_input_info: web::Json<TMAPAPIInput>,
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
@@ -66,8 +66,10 @@ pub async fn get_travel_time_by_driving(
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
+        "startName": api_input_info.start_name,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
+        "endName": api_input_info.end_name,
         "searchOption" : 0, // 경로 탐색 옵션, 0(기본값): 교통최적 + 추천
         "trafficInfo" : "Y",    // 교통 정보 포함 여부, Y: 교통 정보를 포함
         "carType": 0    // 톨게이트 요금에 대한 차종, 0(기본값): 미선택
@@ -99,7 +101,7 @@ pub async fn get_travel_time_by_driving(
 }
 
 pub async fn get_travel_time_by_walking(
-    api_input_info: web::Json<TMAPtransitAPIInput>,
+    api_input_info: web::Json<TMAPAPIInput>,
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
@@ -112,10 +114,10 @@ pub async fn get_travel_time_by_walking(
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
-        "startName": "출발지",
+        "startName": api_input_info.start_name,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
-        "endName": "도착지"
+        "endName": api_input_info.end_name
     });
 
     match http_client

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -98,6 +98,51 @@ pub async fn get_travel_time_by_driving(
     }
 }
 
+pub async fn get_travel_time_by_walking(
+    api_input_info: web::Json<TMAPtransitAPIInput>,
+    app_state: web::Data<AppState>,
+) -> HttpResponse {
+    let http_client = &app_state.http_client;
+    let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1";
+
+    // https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=45
+    // 이 링크에서 각 Body Parameters 확인 !!
+    // TODO: startName, endName 파라미터 또한 api 요청 body로 받아와야 할 듯
+    let request_body = serde_json::json!({
+        "startX": api_input_info.start_x,
+        "startY": api_input_info.start_y,
+        "startName": "출발지",
+        "endX": api_input_info.end_x,
+        "endY": api_input_info.end_y,
+        "endName": "도착지"
+    });
+
+    match http_client
+        .post(tmap_api_endpoint)
+        .header("content-type", "application/json")
+        .header("appKey", app_key)
+        .header("accept", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                // 응답을 JSON으로 변환
+                match response.json::<Value>().await {
+                    Ok(json_response) => HttpResponse::Ok().json(json_response),
+                    Err(_) => HttpResponse::InternalServerError().body("Failed to parse response"),
+                }
+            } else {
+                // TMAP API가 실패 상태 코드를 반환
+                HttpResponse::BadRequest().body("Failed to fetch travel time from TMAP API")
+            }
+        }
+        Err(_) => HttpResponse::InternalServerError().body("Failed to connect to TMAP API"),
+    }
+}
+
 pub async fn test_handler() -> HttpResponse {
     HttpResponse::Ok().body("Test handler called")
 }

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -53,6 +53,48 @@ pub async fn get_travel_time_by_transit(
     }
 }
 
+pub async fn get_travel_time_by_driving(
+    api_input_info: web::Json<TMAPtransitAPIInput>,
+    app_state: web::Data<AppState>,
+) -> HttpResponse {
+    let http_client = &app_state.http_client;
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
+    let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+
+    let request_body = serde_json::json!({
+        "startX": api_input_info.start_x,
+        "startY": api_input_info.start_y,
+        "endX": api_input_info.end_x,
+        "endY": api_input_info.end_y,
+        "totalValue": 2 
+    });
+
+    match http_client
+        .post(tmap_api_endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("appKey", app_key)
+        .header("accept", "application/json")
+        .header("Accept-Language", "ko")
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                // 응답을 JSON으로 변환
+                match response.json::<Value>().await {
+                    Ok(json_response) => HttpResponse::Ok().json(json_response),
+                    Err(_) => HttpResponse::InternalServerError().body("Failed to parse response"),
+                }
+            } else {
+                // TMAP API가 실패 상태 코드를 반환
+                HttpResponse::BadRequest().body("Failed to fetch travel time from TMAP API")
+            }
+        }
+        Err(_) => HttpResponse::InternalServerError().body("Failed to connect to TMAP API"),
+    }
+}
+
 pub async fn test_handler() -> HttpResponse {
     HttpResponse::Ok().body("Test handler called")
 }

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -58,23 +58,26 @@ pub async fn get_travel_time_by_driving(
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
-    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
     let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
 
+    // https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=46#Body_Parameters
+    // 이 링크에서 각 Body Parameters 확인 !!
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
-        "totalValue": 2 
+        "searchOption" : 0, // 경로 탐색 옵션, 0(기본값): 교통최적 + 추천
+        "trafficInfo" : "Y",    // 교통 정보 포함 여부, Y: 교통 정보를 포함
+        "carType": 0    // 톨게이트 요금에 대한 차종, 0(기본값): 미선택
     });
 
     match http_client
         .post(tmap_api_endpoint)
-        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("content-type", "application/json")
         .header("appKey", app_key)
         .header("accept", "application/json")
-        .header("Accept-Language", "ko")
         .json(&request_body)
         .send()
         .await

--- a/sigo-travel-time/src/models.rs
+++ b/sigo-travel-time/src/models.rs
@@ -25,3 +25,28 @@ impl From<web::Json<TMAPtransitAPIInput>> for TMAPtransitAPIInput {
         }
     }
 }
+
+// TMAP API (자동차 & 보행자 경로안내) API input 구조체
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TMAPAPIInput {
+    pub start_x: String,
+    pub start_y: String,
+    pub start_name: String,
+    pub end_x: String,
+    pub end_y: String,
+    pub end_name: String,
+}
+
+// HTTP request 데이터를 Rust 구조체로 변환.
+impl From<web::Json<TMAPAPIInput>> for TMAPAPIInput {
+    fn from(req: web::Json<TMAPAPIInput>) -> Self {
+        TMAPAPIInput {
+            start_x: req.start_x.clone(),
+            start_y: req.start_y.clone(),
+            start_name: req.start_name.clone(),
+            end_x: req.end_x.clone(),
+            end_y: req.end_y.clone(),
+            end_name: req.end_name.clone(),
+        }
+    }
+}

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -6,6 +6,11 @@ use actix_web::web;
 
 pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     let api_path = "/api/v0/travel-time";
-    cfg.service(web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)));
+    cfg.service(
+        web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)),
+    );
+    cfg.service(
+        web::scope(&api_path).route("/driving", web::post().to(get_travel_time_by_driving)),
+    );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -9,7 +9,8 @@ pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope(&api_path)
             .route("/transit", web::post().to(get_travel_time_by_transit))
-            .route("/driving", web::post().to(get_travel_time_by_driving)),
+            .route("/driving", web::post().to(get_travel_time_by_driving))
+            .route("/walking", web::post().to(get_travel_time_by_walking)),
     );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -7,10 +7,9 @@ use actix_web::web;
 pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     let api_path = "/api/v0/travel-time";
     cfg.service(
-        web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)),
-    );
-    cfg.service(
-        web::scope(&api_path).route("/driving", web::post().to(get_travel_time_by_driving)),
+        web::scope(&api_path)
+            .route("/transit", web::post().to(get_travel_time_by_transit))
+            .route("/driving", web::post().to(get_travel_time_by_driving)),
     );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }


### PR DESCRIPTION
# Feat/ TMAP API (자동차 경로안내, 보행자 경로안내) 연동 완료

#1 에서 이어서 개발했습니다.

## 1. TMAP 자동차 경로안내 API
[API Docs URL](https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=46#Request/Response_%EC%98%88%EC%A0%9C)
이 링크에서 자세한 설명 확인 가능

### 접속 route (API 엔드포인트)
```plain text
http://localhost:8080/api/v0/travel-time/driving
```

### Request Body로 전달해야 하는 파라미터 (예시)
```json
{
    "start_x": "127.02961696519651",
    "start_y": "37.58276551823443",
    "start_name": "안암오거리",
    "end_x": "127.0540211996305",
    "end_y": "37.58388311414532",
    "end_name": "해머스미스커피 서울시립대점"
}
```

### 응답 정보 (예시)
중간중간 생략했습니다.
어떤 정보들이 필요할지 추후 논의 필요할 듯
```json
{
    "features": [
        {
            "geometry": {
                "coordinates": [
                    127.02959646040082,
                    37.58275926921031
                ],
                "type": "Point"
            },
            "properties": {
                "description": "안암로 을 따라  방면으로 497m 이동",
                "index": 0,
                "name": "",
                "nextRoadName": "안암로",
                "pointIndex": 0,
                "pointType": "S",
                "taxiFare": 6300,
                "totalDistance": 2827,
                "totalFare": 0,
                "totalTime": 584,
                "turnType": 200
            },
            "type": "Feature"
        },
        {
            "geometry": {
                "coordinates": [
                    [
                        127.02959646040082,
                        37.58275926921031
                    ],
                    ...
                ],
                "traffic": [
                    [
                        0,
                        18,
                        2,
                        23
                    ]
                ],
                "type": "LineString"
            },
            "properties": {
                "description": "안암로, 497m",
                "distance": 497,
                "facilityType": 0,
                "index": 1,
                "lineIndex": 0,
                "name": "안암로",
                "roadType": 6,
                "time": 70
            },
            "type": "Feature"
        },
        {
            "geometry": {
                "coordinates": [
                    127.0328099522479,
                    37.58642834481009
                ],
                "type": "Point"
            },
            "properties": {
                "description": "고대 앞 사거리 에서 홍릉 방면으로 2시 방향 우회전 후 제기로 을 따라 294m 이동 ",
                "index": 2,
                "name": "고대 앞 사거리",
                "nextRoadName": "제기로",
                "pointIndex": 1,
                "pointType": "N",
                "turnType": 18
            },
            "type": "Feature"
        },
        {
            "geometry": {
                "coordinates": [
                    [
                        127.0328099522479,
                        37.58642834481009
                    ],
                    ...
                ],
                "traffic": [
                    [
                        0,
                        10,
                        2,
                        22
                    ]
                ],
                "type": "LineString"
            },
            "properties": {
                "description": "제기로, 294m",
                "distance": 294,
                "facilityType": 0,
                "index": 3,
                "lineIndex": 1,
                "name": "제기로",
                "roadType": 6,
                "time": 48
            },
            "type": "Feature"
        },
        {
            "geometry": {
                "coordinates": [
                    [
                        127.03614020157713,
                        37.58652561564282
                    ],
                    [
                        127.03621241721883,
                        37.586525616942154
                    ]
                ],
                "traffic": [
                    [
                        0,
                        1,
                        2,
                        22
                    ]
                ],
                "type": "LineString"
            },

            ...

        {
            "geometry": {
                "coordinates": [
                    127.0540164276854,
                    37.58381236403508
                ],
                "type": "Point"
            },
            "properties": {
                "description": "도착",
                "index": 15,
                "name": "",
                "nextRoadName": "",
                "pointIndex": 5,
                "pointType": "E",
                "turnType": 201
            },
            "type": "Feature"
        }
    ],
    "type": "FeatureCollection"
}
```

## 2. TMAP 보행자 경로안내 API
[API Docs URL](https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=45)
이 링크에서 자세한 설명 확인 가능
++ 수도권은 잘 지원하는 것 같은데, 지방은 100% 지원하지는 않는 듯. 차차 확장 중이라는 언급이 있다.

### 접속 route (API 엔드포인트)
```plain text
http://localhost:8080/api/v0/travel-time/walking
```

### Request Body로 전달해야 하는 파라미터 (예시)
```json
{
    "start_x": "127.02961696519651",
    "start_y": "37.58276551823443",
    "start_name": "안암오거리",
    "end_x": "127.0540211996305",
    "end_y": "37.58388311414532",
    "end_name": "해머스미스커피 서울시립대점"
}
```

### 응답 정보 (예시)
```plain text
... 생략 ...
```

## 3. 추후 개발 예정 사항
- (회의 후) API Response 가공 (필요한 데이터 살리고, 필요 없는 것들은 쳐내기)
- 에러 핸들링 고도화
- 알람에 등록된 시간에 따른 /api/v0/xxx 자동 fetch 로직 (개념 공부 및 구현) 