### PR TITLE
travel-time API 엔드포인트 변경

### DIFF
--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -1,7 +1,7 @@
 // sigo-travel-time/src/handlers.rs
 // 각 HTTP 요청을 수행하는 핸들러 함수들을 작성 (서비스)
 
-use super::models::TMAPtransitAPIInput;
+use super::models::{TMAPAPIInput, TMAPtransitAPIInput};
 use super::state::AppState;
 use actix_web::{web, HttpResponse};
 use serde_json::Value;
@@ -54,7 +54,7 @@ pub async fn get_travel_time_by_transit(
 }
 
 pub async fn get_travel_time_by_driving(
-    api_input_info: web::Json<TMAPtransitAPIInput>,
+    api_input_info: web::Json<TMAPAPIInput>,
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
@@ -66,8 +66,10 @@ pub async fn get_travel_time_by_driving(
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
+        "startName": api_input_info.start_name,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
+        "endName": api_input_info.end_name,
         "searchOption" : 0, // 경로 탐색 옵션, 0(기본값): 교통최적 + 추천
         "trafficInfo" : "Y",    // 교통 정보 포함 여부, Y: 교통 정보를 포함
         "carType": 0    // 톨게이트 요금에 대한 차종, 0(기본값): 미선택
@@ -99,7 +101,7 @@ pub async fn get_travel_time_by_driving(
 }
 
 pub async fn get_travel_time_by_walking(
-    api_input_info: web::Json<TMAPtransitAPIInput>,
+    api_input_info: web::Json<TMAPAPIInput>,
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
@@ -112,10 +114,10 @@ pub async fn get_travel_time_by_walking(
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
-        "startName": "출발지",
+        "startName": api_input_info.start_name,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
-        "endName": "도착지"
+        "endName": api_input_info.end_name
     });
 
     match http_client

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -98,6 +98,51 @@ pub async fn get_travel_time_by_driving(
     }
 }
 
+pub async fn get_travel_time_by_walking(
+    api_input_info: web::Json<TMAPtransitAPIInput>,
+    app_state: web::Data<AppState>,
+) -> HttpResponse {
+    let http_client = &app_state.http_client;
+    let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1";
+
+    // https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=45
+    // 이 링크에서 각 Body Parameters 확인 !!
+    // TODO: startName, endName 파라미터 또한 api 요청 body로 받아와야 할 듯
+    let request_body = serde_json::json!({
+        "startX": api_input_info.start_x,
+        "startY": api_input_info.start_y,
+        "startName": "출발지",
+        "endX": api_input_info.end_x,
+        "endY": api_input_info.end_y,
+        "endName": "도착지"
+    });
+
+    match http_client
+        .post(tmap_api_endpoint)
+        .header("content-type", "application/json")
+        .header("appKey", app_key)
+        .header("accept", "application/json")
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                // 응답을 JSON으로 변환
+                match response.json::<Value>().await {
+                    Ok(json_response) => HttpResponse::Ok().json(json_response),
+                    Err(_) => HttpResponse::InternalServerError().body("Failed to parse response"),
+                }
+            } else {
+                // TMAP API가 실패 상태 코드를 반환
+                HttpResponse::BadRequest().body("Failed to fetch travel time from TMAP API")
+            }
+        }
+        Err(_) => HttpResponse::InternalServerError().body("Failed to connect to TMAP API"),
+    }
+}
+
 pub async fn test_handler() -> HttpResponse {
     HttpResponse::Ok().body("Test handler called")
 }

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -53,6 +53,48 @@ pub async fn get_travel_time_by_transit(
     }
 }
 
+pub async fn get_travel_time_by_driving(
+    api_input_info: web::Json<TMAPtransitAPIInput>,
+    app_state: web::Data<AppState>,
+) -> HttpResponse {
+    let http_client = &app_state.http_client;
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
+    let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+
+    let request_body = serde_json::json!({
+        "startX": api_input_info.start_x,
+        "startY": api_input_info.start_y,
+        "endX": api_input_info.end_x,
+        "endY": api_input_info.end_y,
+        "totalValue": 2 
+    });
+
+    match http_client
+        .post(tmap_api_endpoint)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("appKey", app_key)
+        .header("accept", "application/json")
+        .header("Accept-Language", "ko")
+        .json(&request_body)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status().is_success() {
+                // 응답을 JSON으로 변환
+                match response.json::<Value>().await {
+                    Ok(json_response) => HttpResponse::Ok().json(json_response),
+                    Err(_) => HttpResponse::InternalServerError().body("Failed to parse response"),
+                }
+            } else {
+                // TMAP API가 실패 상태 코드를 반환
+                HttpResponse::BadRequest().body("Failed to fetch travel time from TMAP API")
+            }
+        }
+        Err(_) => HttpResponse::InternalServerError().body("Failed to connect to TMAP API"),
+    }
+}
+
 pub async fn test_handler() -> HttpResponse {
     HttpResponse::Ok().body("Test handler called")
 }

--- a/sigo-travel-time/src/handlers.rs
+++ b/sigo-travel-time/src/handlers.rs
@@ -58,23 +58,26 @@ pub async fn get_travel_time_by_driving(
     app_state: web::Data<AppState>,
 ) -> HttpResponse {
     let http_client = &app_state.http_client;
-    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
     let app_key = env::var("TMAP_API_KEY").expect("Failed to get TMAP_API_KEY in .env");
+    let tmap_api_endpoint = "https://apis.openapi.sk.com/tmap/routes?version=1";
 
+    // https://openapi.sk.com/products/detail?svcSeq=4&menuSeq=46#Body_Parameters
+    // 이 링크에서 각 Body Parameters 확인 !!
     let request_body = serde_json::json!({
         "startX": api_input_info.start_x,
         "startY": api_input_info.start_y,
         "endX": api_input_info.end_x,
         "endY": api_input_info.end_y,
-        "totalValue": 2 
+        "searchOption" : 0, // 경로 탐색 옵션, 0(기본값): 교통최적 + 추천
+        "trafficInfo" : "Y",    // 교통 정보 포함 여부, Y: 교통 정보를 포함
+        "carType": 0    // 톨게이트 요금에 대한 차종, 0(기본값): 미선택
     });
 
     match http_client
         .post(tmap_api_endpoint)
-        .header("Content-Type", "application/x-www-form-urlencoded")
+        .header("content-type", "application/json")
         .header("appKey", app_key)
         .header("accept", "application/json")
-        .header("Accept-Language", "ko")
         .json(&request_body)
         .send()
         .await

--- a/sigo-travel-time/src/models.rs
+++ b/sigo-travel-time/src/models.rs
@@ -5,36 +5,34 @@ use actix_web::web;
 // use chrono::NaiveDateTime; // 등록 시간 기록하려고 쓰는 서드파티 크레이트
 use serde::{Deserialize, Serialize}; // Rust 데이터 구조 - HTTP msg 전송용 포맷 역직렬화, 직렬화
 
-// TMAP 대중교통 API 인풋 구조체
-#[derive(Deserialize, Serialize, Debug, Clone)]
-pub struct TMAPtransitAPIInput {
-    pub start_x: String,
-    pub start_y: String,
-    pub end_x: String,
-    pub end_y: String,
-}
+// // TMAP 대중교통 API 인풋 구조체
+// #[derive(Deserialize, Serialize, Debug, Clone)]
+// pub struct TMAPtransitAPIInput {
+//     pub start_x: String,
+//     pub start_y: String,
+//     pub end_x: String,
+//     pub end_y: String,
+// }
 
-// HTTP request 데이터를 Rust 구조체로 변환.
-impl From<web::Json<TMAPtransitAPIInput>> for TMAPtransitAPIInput {
-    fn from(req: web::Json<TMAPtransitAPIInput>) -> Self {
-        TMAPtransitAPIInput {
-            start_x: req.start_x.clone(),
-            start_y: req.start_y.clone(),
-            end_x: req.end_x.clone(),
-            end_y: req.end_y.clone(),
-        }
-    }
-}
+// // HTTP request 데이터를 Rust 구조체로 변환.
+// impl From<web::Json<TMAPtransitAPIInput>> for TMAPtransitAPIInput {
+//     fn from(req: web::Json<TMAPtransitAPIInput>) -> Self {
+//         TMAPtransitAPIInput {
+//             start_x: req.start_x.clone(),
+//             start_y: req.start_y.clone(),
+//             end_x: req.end_x.clone(),
+//             end_y: req.end_y.clone(),
+//         }
+//     }
+// }
 
 // TMAP API (자동차 & 보행자 경로안내) API input 구조체
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct TMAPAPIInput {
     pub start_x: String,
     pub start_y: String,
-    pub start_name: String,
     pub end_x: String,
     pub end_y: String,
-    pub end_name: String,
 }
 
 // HTTP request 데이터를 Rust 구조체로 변환.
@@ -43,10 +41,13 @@ impl From<web::Json<TMAPAPIInput>> for TMAPAPIInput {
         TMAPAPIInput {
             start_x: req.start_x.clone(),
             start_y: req.start_y.clone(),
-            start_name: req.start_name.clone(),
             end_x: req.end_x.clone(),
             end_y: req.end_y.clone(),
-            end_name: req.end_name.clone(),
         }
     }
+}
+
+#[derive(Deserialize)]
+pub struct Transport {
+    pub transport: String,
 }

--- a/sigo-travel-time/src/models.rs
+++ b/sigo-travel-time/src/models.rs
@@ -25,3 +25,28 @@ impl From<web::Json<TMAPtransitAPIInput>> for TMAPtransitAPIInput {
         }
     }
 }
+
+// TMAP API (자동차 & 보행자 경로안내) API input 구조체
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TMAPAPIInput {
+    pub start_x: String,
+    pub start_y: String,
+    pub start_name: String,
+    pub end_x: String,
+    pub end_y: String,
+    pub end_name: String,
+}
+
+// HTTP request 데이터를 Rust 구조체로 변환.
+impl From<web::Json<TMAPAPIInput>> for TMAPAPIInput {
+    fn from(req: web::Json<TMAPAPIInput>) -> Self {
+        TMAPAPIInput {
+            start_x: req.start_x.clone(),
+            start_y: req.start_y.clone(),
+            start_name: req.start_name.clone(),
+            end_x: req.end_x.clone(),
+            end_y: req.end_y.clone(),
+            end_name: req.end_name.clone(),
+        }
+    }
+}

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -6,6 +6,11 @@ use actix_web::web;
 
 pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     let api_path = "/api/v0/travel-time";
-    cfg.service(web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)));
+    cfg.service(
+        web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)),
+    );
+    cfg.service(
+        web::scope(&api_path).route("/driving", web::post().to(get_travel_time_by_driving)),
+    );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -9,7 +9,8 @@ pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope(&api_path)
             .route("/transit", web::post().to(get_travel_time_by_transit))
-            .route("/driving", web::post().to(get_travel_time_by_driving)),
+            .route("/driving", web::post().to(get_travel_time_by_driving))
+            .route("/walking", web::post().to(get_travel_time_by_walking)),
     );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -8,9 +8,7 @@ pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     let api_path = "/api/v0/travel-time";
     cfg.service(
         web::scope(&api_path)
-            .route("/transit", web::post().to(get_travel_time_by_transit))
-            .route("/driving", web::post().to(get_travel_time_by_driving))
-            .route("/walking", web::post().to(get_travel_time_by_walking)),
+            .route("", web::post().to(get_travel_time))
     );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }

--- a/sigo-travel-time/src/routes.rs
+++ b/sigo-travel-time/src/routes.rs
@@ -7,10 +7,9 @@ use actix_web::web;
 pub fn travel_time_routes(cfg: &mut web::ServiceConfig) {
     let api_path = "/api/v0/travel-time";
     cfg.service(
-        web::scope(&api_path).route("/transit", web::post().to(get_travel_time_by_transit)),
-    );
-    cfg.service(
-        web::scope(&api_path).route("/driving", web::post().to(get_travel_time_by_driving)),
+        web::scope(&api_path)
+            .route("/transit", web::post().to(get_travel_time_by_transit))
+            .route("/driving", web::post().to(get_travel_time_by_driving)),
     );
     cfg.service(web::scope("/test").route("/", web::get().to(test_handler)));
 }


### PR DESCRIPTION
# travel-time API 엔드포인트 변경

@ddoong10 요청으로 API 엔드포인트 변경

## 기존 API 엔드포인트
```
/api/v0/travel-time/driving
/api/v0/travel-time/driving
/api/v0/travel-time/driving
```
이런 식으로 엔드포인트가 다 나뉘어져 있었음.

## 변경한 API 엔드포인트
1. `/api/v0/travel-time?transport=xxx` 로 통일
2. `'transport'` Query 파라미터에 이동수단을 받음
3. 관련해서 Transport 구조체 추가, 라우팅 방식 변경, 핸들러 수정 등의 과정 진행

## 'driving' 이동수단 선택 시 API Response 변경

엔드포인트 변경과는 관련된 것은 아니지만, 변경하는 김에 .. 수정했습니다.

![postman image](https://github.com/user-attachments/assets/67395fa3-e848-4910-bf2c-e3aac2fc4162)

```json
{
    "features": [
        {
            "properties": {
                "taxiFare": 8500,
                "totalDistance": 2827,
                "totalFare": 0,
                "totalTime": 508
            },
            "type": "Feature"
        }
    ],
    "type": "FeatureCollection"
}
```
위 코드처럼 필수적인 값만 받아오도록 수정

## Future work
- Flutter 단에서 로컬 저장소에 저장되어있는 알람의 시간 값을 보고, 자동으로 출발지 & 이동시간 받아오면서 이 API 호출하도록 하는 로직 개발 (알고리즘 & 구현 방식 고민)
- /travel-time 응답 결과 기획에 맞게 최적화 (totalTime)은 바운드를 널널하게 잡는 게 좋을 듯
- 이동수단 = 자전거로 설정하는 기획이 외부API 호출 상에서의 이슈로 잠정 보류. 해결방안 있을지 고민해보기
